### PR TITLE
Follow Caddy's best practices

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -28,17 +28,14 @@
     }
 
     # Notify Push
-    route /push/* {
-        uri strip_prefix /push
+    handle_path /push/* {
         reverse_proxy {$NOTIFY_PUSH_HOST}:7867
     }
 
     # Onlyoffice
-    route /onlyoffice/* {
-        uri strip_prefix /onlyoffice
+    handle_path /onlyoffice/* {
         reverse_proxy {$ONLYOFFICE_HOST}:80 {
             header_up X-Forwarded-Host {http.request.host}/onlyoffice
-            header_up X-Forwarded-Proto https
         }
     }
 


### PR DESCRIPTION
I made a post in Caddy's community about my Nextcloud's configuration wich includes onlyoffice block as it's shown here and they made this change according to Caddy best practices of handling this route.

Source: https://caddy.community/t/caddy-v2-configuration-nextcloud-docker-php-fpm-with-rules-from-htaccess/20662/2

Also forwarding X-Forwarded-Proto https is not needed as Caddy sets it automatically: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy